### PR TITLE
Release version 1.16.2 and testlight 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the **Multimeter** extension will be documented in this file.
 
+## [1.16.2]
+
+- Fix environment variable extraction issue
+- Update website
+
 ## [1.16.1]
 
 - Improve assistant behavior and prompt handling

--- a/mmtcli/package.json
+++ b/mmtcli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmt-testlight",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Multimeter CLI test runner",
   "type": "module",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "mshobeyri",
   "displayName": "Multimeter",
   "description": "API test tools",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/mshobeyri/multimeter.git"


### PR DESCRIPTION
## Summary
- release Multimeter extension 1.16.2
- release testlight 0.4.0
- include changelog and package version updates

## Included changes
- bump root extension version to 1.16.2
- add 1.16.2 changelog entry
- bump CLI version to 0.4.0